### PR TITLE
10 to 20 player modes for: Rev, Wiz, and Cult

### DIFF
--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -26,10 +26,9 @@
 	antag_flag = BE_CULTIST
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 20
-	required_enemies = 6
-	recommended_enemies = 6
-
+	required_players = 10
+	required_enemies = 2 
+	recommended_enemies = 4
 
 	var/finished = 0
 
@@ -38,7 +37,7 @@
 
 	var/eldergod = 1 //for the summon god objective
 
-	var/acolytes_needed = 10 //for the survive objective
+	var/acolytes_needed = 7 //for the survive objective
 	var/acolytes_survived = 0
 
 
@@ -55,7 +54,17 @@
 		cult_objectives += "eldergod"
 		cult_objectives += "sacrifice"
 
+	//adjust game mode for player numbers
+	if(num_players() < 20)
+		set_runecults(setELDERGOD_CULTS=6, setCONVERT_CULTS=2, setSACRIFICE_CULTS=2)
+		
+	if(num_players() >= 20)
+		required_enemies = 4
+		recommended_enemies = 6
+		acolytes_needed = 10
+
 	if(num_players() >= 30)
+		required_enemies = 6
 		recommended_enemies = 9	// 3+3+3 - d' magic number o' magic numbars mon
 		acolytes_needed = 15
 
@@ -122,7 +131,7 @@
 				else
 					explanation = "Free objective."
 			if("eldergod")
-				explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if nine cultists stand on and around it."
+				explanation = "Summon Nar-Sie via the use of the appropriate rune (Hell join self). It will only work if [ELDERGOD_CULTS] cultists stand on and around it."
 		cult_mind.current << "<B>Objective #[obj_count]</B>: [explanation]"
 		cult_mind.memory += "<B>Objective #[obj_count]</B>: [explanation]<BR>"
 	cult_mind.current << "The Geometer of Blood grants you the knowledge to sacrifice non-believers. (Hell Blood Join)"

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -339,106 +339,108 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 	throw_range = 5
 	w_class = 2.0
 	var/notedat = ""
-	var/tomedat = ""
 	var/list/words = list("ire" = "ire", "ego" = "ego", "nahlizet" = "nahlizet", "certum" = "certum", "veri" = "veri", "jatkaa" = "jatkaa", "balaq" = "balaq", "mgar" = "mgar", "karazet" = "karazet", "geeri" = "geeri")
 
 
-	tomedat = {"<html>
-				<head>
-				<style>
-				h1 {font-size: 25px; margin: 15px 0px 5px;}
-				h2 {font-size: 20px; margin: 15px 0px 5px;}
-				li {margin: 2px 0px 2px 15px;}
-				ul {list-style: none; margin: 5px; padding: 0px;}
-				ol {margin: 5px; padding: 0px 15px;}
-				</style>
-				</head>
-				<body>
-				<h1>The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood.</h1>
+var/TOMEDAT = ""
 
-				<i>The book is written in an unknown dialect, there are lots of pictures of various complex geometric shapes. You find some notes in english that give you basic understanding of the many runes written in the book. The notes give you an understanding what the words for the runes should be. However, you do not know how to write all these words in this dialect.</i><br>
-				<i>Below is the summary of the runes.</i> <br>
+proc/update_tome()
+	TOMEDAT = {"<html>
+			<head>
+			<style>
+			h1 {font-size: 25px; margin: 15px 0px 5px;}
+			h2 {font-size: 20px; margin: 15px 0px 5px;}
+			li {margin: 2px 0px 2px 15px;}
+			ul {list-style: none; margin: 5px; padding: 0px;}
+			ol {margin: 5px; padding: 0px 15px;}
+			</style>
+			</head>
+			<body>
+			<h1>The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood.</h1>
 
-				<h2>Contents</h2>
-				<p>
-				<b>Teleport self: </b>Travel Self (word)<br>
-				<b>Teleport other: </b>Travel Other (word)<br>
-				<b>Summon new tome: </b>See Blood Hell<br>
-				<b>Convert a person: </b>Join Blood Self<br>
-				<b>Summon Nar-Sie: </b>Hell Join Self<br>
-				<b>Disable technology: </b>Destroy See Technology<br>
-				<b>Drain blood: </b>Travel Blood Self<br>
-				<b>Raise dead: </b>Blood Join Hell<br>
-				<b>Hide runes: </b>Hide See Blood<br>
-				<b>Reveal hidden runes: </b>Blood See Hide<br>
-				<b>Leave your body: </b>Hell travel self<br>
-				<b>Ghost Manifest: </b>Blood See Travel<br>
-				<b>Imbue a talisman: </b>Hell Technology Join<br>
-				<b>Sacrifice: </b>Hell Blood Join<br>
-				<b>Create a wall: </b>Destroy Travel Self<br>
-				<b>Summon cultist: </b>Join Other Self<br>
-				<b>Free a cultist: </b>Travel technology other<br>
-				<b>Deafen: </b>Hide Other See<br>
-				<b>Blind: </b>Destroy See Other<br>
-				<b>Blood Boil: </b>Destroy See Blood<br>
-				<b>Communicate: </b>Self Other Technology<br>
-				<b>Stun: </b>Join Hide Technology<br>
-				<b>Summon Cultist Armor: </b>Hell Destroy Other<br>
-				<b>See Invisible: </b>See Hell Join<br>
-				</p>
-				<h2>Rune Descriptions</h2>
-				<h3>Teleport self</h3>
-				Teleport rune is a special rune, as it only needs two words, with the third word being destination. Basically, when you have two runes with the same destination, invoking one will teleport you to the other one. If there are more than 2 runes, you will be teleported to a random one. Runes with different third words will create separate networks. You can imbue this rune into a talisman, giving you a great escape mechanism.<br>
-				<h3>Teleport other</h3>
-				Teleport other allows for teleportation for any movable object to another rune with the same third word. <br>
-				<h3>Summon new tome</h3>
-				Invoking this rune summons a new arcane tome.
-				<h3>Convert a person</h3>
-				This rune opens target's mind to the realm of Nar-Sie, which usually results in this person joining the cult. However, some people (mostly the ones who posess high authority) have strong enough will to stay true to their old ideals. <br>
-				<h3>Summon Nar-Sie</h3>
-				The ultimate rune. It summons the Avatar of Nar-Sie himself, tearing a huge hole in reality and consuming everything around it. Summoning it is the final goal of any cult.<br>
-				<h3>Disable Technology</h3>
-				Invoking this rune creates a strong electromagnetic pulse in a small radius, making it basically analogic to an EMP grenade. You can imbue this rune into a talisman, making it a decent defensive item.<br>
-				<h3>Drain Blood</h3>
-				This rune instantly heals you of some brute damage at the expense of a person placed on top of the rune. Whenever you invoke a drain rune, ALL drain runes on the station are activated, draining blood from anyone located on top of those runes. This includes yourself, though the blood you drain from yourself just comes back to you. This might help you identify this rune when studying words. One drain gives up to 25HP per each victim, but you can repeat it if you need more. Draining only works on living people, so you might need to recharge your "Battery" once its empty. Drinking too much blood at once might cause blood hunger.<br>
-				<h3>Raise Dead</h3>
-				This rune allows for the resurrection of any dead person. You will need a dead human body and a living human sacrifice. Make 2 raise dead runes. Put a living non-braindead human on top of one, and a dead body on the other one. When you invoke the rune, the life force of the living human will be transferred into the dead body, allowing a ghost standing on top of the dead body to enter it, instantly and fully healing it. Use other runes to ensure there is a ghost ready to be resurrected.<br>
-				<h3>Hide runes</h3>
-				This rune makes all nearby runes completely invisible. They are still there and will work if activated somehow, but you cannot invoke them directly if you do not see them.<br>
-				<h3>Reveal runes</h3>
-				This rune is made to reverse the process of hiding a rune. It reveals all hidden runes in a rather large area around it.
-				<h3>Leave your body</h3>
-				This rune gently rips your soul out of your body, leaving it intact. You can observe the surroundings as a ghost as well as communicate with other ghosts. Your body takes damage while you are there, so ensure your journey is not too long, or you might never come back.<br>
-				<h3>Manifest a ghost</h3>
-				Unlike the Raise Dead rune, this rune does not require any special preparations or vessels. Instead of using full lifeforce of a sacrifice, it will drain YOUR lifeforce. Stand on the rune and invoke it. If theres a ghost standing over the rune, it will materialise, and will live as long as you dont move off the rune or die. You can put a paper with a name on the rune to make the new body look like that person.<br>
-				<h3>Imbue a talisman</h3>
-				This rune allows you to imbue the magic of some runes into paper talismans. Create an imbue rune, then an appropriate rune beside it. Put an empty piece of paper on the imbue rune and invoke it. You will now have a one-use talisman with the power of the target rune. Using a talisman drains some health, so be careful with it. You can imbue a talisman with power of the following runes: summon tome, reveal, conceal, teleport, tisable technology, communicate, deafen, blind and stun.<br>
-				<h3>Sacrifice</h3>
-				Sacrifice rune allows you to sacrifice a living thing or a body to the Geometer of Blood. Monkeys and dead humans are the most basic sacrifices, they might or might not be enough to gain His favor. A living human is what a real sacrifice should be, however, you will need 3 people chanting the invocation to sacrifice a living person.
-				<h3>Create a wall</h3>
-				Invoking this rune solidifies the air above it, creating an an invisible wall. To remove the wall, simply invoke the rune again.
-				<h3>Summon cultist</h3>
-				This rune allows you to summon a fellow cultist to your location. The target cultist must be unhandcuffed ant not buckled to anything. You also need to have 3 people chanting at the rune to successfully invoke it. Invoking it takes heavy strain on the bodies of all chanting cultists.<br>
-				<h3>Free a cultist</h3>
-				This rune unhandcuffs and unbuckles any cultist of your choice, no matter where he is. Invoking it takes heavy strain on the bodies of all chanting cultists.<br>
-				<h3>Deafen</h3>
-				This rune temporarily deafens all non-cultists around you.<br>
-				<h3>Blind</h3>
-				This rune temporarily blinds all non-cultists around you. Very robust. Use together with the deafen rune to leave your enemies completely helpless.<br>
-				<h3>Blood boil</h3>
-				This rune boils the blood all non-cultists in visible range. The damage is enough to instantly critically hurt any person. You need 3 cultists invoking the rune for it to work. This rune is unreliable and may cause unpredicted effect when invoked. It also drains significant amount of your health when successfully invoked.<br>
-				<h3>Communicate</h3>
-				Invoking this rune allows you to relay a message to all cultists on the station and nearby space objects.
-				<h3>Stun</h3>
-				Unlike other runes, this ons is supposed to be used in talisman form. When invoked directly, it simply releases some dark energy, briefly stunning everyone around. When imbued into a talisman, you can force all of its energy into one person, stunning him so hard he cant even speak. However, effect wears off rather fast.<br>
-				<h3>Equip Armor</h3>
-				When this rune is invoked, either from a rune or a talisman, it will equip the user with the armor of the followers of Nar-Sie. To use this rune to its fullest extent, make sure you are not wearing any form of headgear, armor, gloves or shoes, and make sure you are not holding anything in your hands.<br>
-				<h3>See Invisible</h3>
-				When invoked when standing on it, this rune allows the user to see the the world beyond as long as he does not move.<br>
-				</body>
-				</html>
-				"}
+			<i>The book is written in an unknown dialect, there are lots of pictures of various complex geometric shapes. You find some notes in english that give you basic understanding of the many runes written in the book. The notes give you an understanding what the words for the runes should be. However, you do not know how to write all these words in this dialect.</i><br>
+			<i>Below is the summary of the runes.</i> <br>
 
+			<h2>Contents</h2>
+			<p>
+			<b>Teleport self: </b>Travel Self (word)<br>
+			<b>Teleport other ([ITEMPORT_CULTS]): </b>Travel Other (word)<br>
+			<b>Summon new tome: </b>See Blood Hell<br>
+			<b>Convert a person ([CONVERT_CULTS]): </b>Join Blood Self<br>
+			<b>Summon Nar-Sie ([ELDERGOD_CULTS]): </b>Hell Join Self<br>
+			<b>Disable technology: </b>Destroy See Technology<br>
+			<b>Drain blood: </b>Travel Blood Self<br>
+			<b>Raise dead: </b>Blood Join Hell<br>
+			<b>Hide runes: </b>Hide See Blood<br>
+			<b>Reveal hidden runes: </b>Blood See Hide<br>
+			<b>Leave your body: </b>Hell travel self<br>
+			<b>Ghost Manifest: </b>Blood See Travel<br>
+			<b>Imbue a talisman: </b>Hell Technology Join<br>
+			<b>Sacrifice ([SACRIFICE_CULTS]): </b>Hell Blood Join<br>
+			<b>Create a wall: </b>Destroy Travel Self<br>
+			<b>Summon cultist ([CULTSUMMON_CULTS]): </b>Join Other Self<br>
+			<b>Free a cultist ([FREEDOM_CULTS]): </b>Travel technology other<br>
+			<b>Deafen: </b>Hide Other See<br>
+			<b>Blind: </b>Destroy See Other<br>
+			<b>Blood Boil ([BLOODBOIL_CULTS]): </b>Destroy See Blood<br>
+			<b>Communicate: </b>Self Other Technology<br>
+			<b>Stun: </b>Join Hide Technology<br>
+			<b>Summon Cultist Armor: </b>Hell Destroy Other<br>
+			<b>See Invisible: </b>See Hell Join<br>
+			</p>
+			<h2>Rune Descriptions</h2>
+			<h3>Teleport self</h3>
+			Teleport rune is a special rune, as it only needs two words, with the third word being destination. Basically, when you have two runes with the same destination, invoking one will teleport you to the other one. If there are more than 2 runes, you will be teleported to a random one. Runes with different third words will create separate networks. You can imbue this rune into a talisman, giving you a great escape mechanism.<br>
+			<h3>Teleport other</h3>
+			Teleport other allows for teleportation for any movable object to another rune with the same third word. Requires [ITEMPORT_CULTS] cultists.<br>
+			<h3>Summon new tome</h3>
+			Invoking this rune summons a new arcane tome.
+			<h3>Convert a person</h3>
+			This rune opens target's mind to the realm of Nar-Sie, which usually results in this person joining the cult. However, some people (mostly the ones who posess high authority) have strong enough will to stay true to their old ideals. Requires [CONVERT_CULTS] cultists.<br>
+			<h3>Summon Nar-Sie</h3>
+			The ultimate rune. It summons the Avatar of Nar-Sie himself, tearing a huge hole in reality and consuming everything around it. Summoning it is the final goal of any cult. Requires [ELDERGOD_CULTS].<br>
+			<h3>Disable Technology</h3>
+			Invoking this rune creates a strong electromagnetic pulse in a small radius, making it basically analogic to an EMP grenade. You can imbue this rune into a talisman, making it a decent defensive item.<br>
+			<h3>Drain Blood</h3>
+			This rune instantly heals you of some brute damage at the expense of a person placed on top of the rune. Whenever you invoke a drain rune, ALL drain runes on the station are activated, draining blood from anyone located on top of those runes. This includes yourself, though the blood you drain from yourself just comes back to you. This might help you identify this rune when studying words. One drain gives up to 25HP per each victim, but you can repeat it if you need more. Draining only works on living people, so you might need to recharge your "Battery" once its empty. Drinking too much blood at once might cause blood hunger.<br>
+			<h3>Raise Dead</h3>
+			This rune allows for the resurrection of any dead person. You will need a dead human body and a living human sacrifice. Make 2 raise dead runes. Put a living non-braindead human on top of one, and a dead body on the other one. When you invoke the rune, the life force of the living human will be transferred into the dead body, allowing a ghost standing on top of the dead body to enter it, instantly and fully healing it. Use other runes to ensure there is a ghost ready to be resurrected.<br>
+			<h3>Hide runes</h3>
+			This rune makes all nearby runes completely invisible. They are still there and will work if activated somehow, but you cannot invoke them directly if you do not see them.<br>
+			<h3>Reveal runes</h3>
+			This rune is made to reverse the process of hiding a rune. It reveals all hidden runes in a rather large area around it.
+			<h3>Leave your body</h3>
+			This rune gently rips your soul out of your body, leaving it intact. You can observe the surroundings as a ghost as well as communicate with other ghosts. Your body takes damage while you are there, so ensure your journey is not too long, or you might never come back.<br>
+			<h3>Manifest a ghost</h3>
+			Unlike the Raise Dead rune, this rune does not require any special preparations or vessels. Instead of using full lifeforce of a sacrifice, it will drain YOUR lifeforce. Stand on the rune and invoke it. If theres a ghost standing over the rune, it will materialise, and will live as long as you dont move off the rune or die. You can put a paper with a name on the rune to make the new body look like that person.<br>
+			<h3>Imbue a talisman</h3>
+			This rune allows you to imbue the magic of some runes into paper talismans. Create an imbue rune, then an appropriate rune beside it. Put an empty piece of paper on the imbue rune and invoke it. You will now have a one-use talisman with the power of the target rune. Using a talisman drains some health, so be careful with it. You can imbue a talisman with power of the following runes: summon tome, reveal, conceal, teleport, tisable technology, communicate, deafen, blind and stun.<br>
+			<h3>Sacrifice</h3>
+			Sacrifice rune allows you to sacrifice a living thing or a body to the Geometer of Blood. Monkeys and dead humans are the most basic sacrifices, they might or might not be enough to gain His favor. A living human is what a real sacrifice should be, however, you will need 3 people chanting the invocation to sacrifice a living person. Requires [SACRIFICE_CULTS] cultists.<br>
+			<h3>Create a wall</h3>
+			Invoking this rune solidifies the air above it, creating an an invisible wall. To remove the wall, simply invoke the rune again.
+			<h3>Summon cultist</h3>
+			This rune allows you to summon a fellow cultist to your location. The target cultist must be unhandcuffed ant not buckled to anything. You also need to have 3 people chanting at the rune to successfully invoke it. Invoking it takes heavy strain on the bodies of all chanting cultists. Requires [CULTSUMMON_CULTS] cultists.<br>
+			<h3>Free a cultist</h3>
+			This rune unhandcuffs and unbuckles any cultist of your choice, no matter where he is. Invoking it takes heavy strain on the bodies of all chanting cultists. Requires [FREEDOM_CULTS] cultists.<br>
+			<h3>Deafen</h3>
+			This rune temporarily deafens all non-cultists around you.<br>
+			<h3>Blind</h3>
+			This rune temporarily blinds all non-cultists around you. Very robust. Use together with the deafen rune to leave your enemies completely helpless.<br>
+			<h3>Blood boil</h3>
+			This rune boils the blood all non-cultists in visible range. The damage is enough to instantly critically hurt any person. You need 3 cultists invoking the rune for it to work. This rune is unreliable and may cause unpredicted effect when invoked. It also drains significant amount of your health when successfully invoked. Requires [BLOODBOIL_CULTS] cultists to work.<br>
+			<h3>Communicate</h3>
+			Invoking this rune allows you to relay a message to all cultists on the station and nearby space objects.
+			<h3>Stun</h3>
+			Unlike other runes, this ons is supposed to be used in talisman form. When invoked directly, it simply releases some dark energy, briefly stunning everyone around. When imbued into a talisman, you can force all of its energy into one person, stunning him so hard he cant even speak. However, effect wears off rather fast.<br>
+			<h3>Equip Armor</h3>
+			When this rune is invoked, either from a rune or a talisman, it will equip the user with the armor of the followers of Nar-Sie. To use this rune to its fullest extent, make sure you are not wearing any form of headgear, armor, gloves or shoes, and make sure you are not holding anything in your hands.<br>
+			<h3>See Invisible</h3>
+			When invoked when standing on it, this rune allows the user to see the the world beyond as long as he does not move.<br>
+			</body>
+			</html>
+			"}
+update_tome()
 
 /obj/item/weapon/tome/Topic(href,href_list[])
 	if (src.loc == usr)
@@ -451,7 +453,7 @@ var/engwords = list("travel", "blood", "join", "hell", "destroy", "technology", 
 			if("read")
 				if(usr.get_active_hand() != src)
 					return
-				usr << browse("[tomedat]", "window=Arcane Tome")
+				usr << browse("[TOMEDAT]", "window=Arcane Tome")
 				return
 			if("change")
 				words[words[number]] = input("Enter the translation for [words[number]]", "Word notes") in engwords

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -1,4 +1,32 @@
 var/list/sacrificed = list()
+// Sets number of cultists required for various runes, default values below are for 20+ player rounds
+var/CONVERT_CULTS = 3
+var/ELDERGOD_CULTS = 9
+var/SACRIFICE_CULTS = 3
+var/ITEMPORT_CULTS = 1
+var/FREEDOM_CULTS = 1
+var/CULTSUMMON_CULTS = 3
+var/BLOODBOIL_CULTS = 3
+var/BURNINGBLOOD_CULTS = 5
+
+proc/set_runecults( setELDERGOD_CULTS = null, setCONVERT_CULTS = null, setSACRIFICE_CULTS = null, setITEMPORT_CULTS = null, setFREEDOM_CULTS = null, setCULTSUMMON_CULTS = null, setBLOODBOIL_CULTS = null, setBURNINGBLOOD_CULTS = null ) //Convenience Method for setting number of cultists required for runes, automatically updates tome
+	if(setELDERGOD_CULTS)
+		ELDERGOD_CULTS = setELDERGOD_CULTS
+	if(setCONVERT_CULTS)
+		CONVERT_CULTS = setCONVERT_CULTS
+	if(setSACRIFICE_CULTS)
+		SACRIFICE_CULTS = setSACRIFICE_CULTS
+	if(setITEMPORT_CULTS)
+		ITEMPORT_CULTS = setITEMPORT_CULTS
+	if(setFREEDOM_CULTS)
+		FREEDOM_CULTS = setFREEDOM_CULTS 
+	if(setCULTSUMMON_CULTS)
+		CULTSUMMON_CULTS = setCULTSUMMON_CULTS
+	if(setBLOODBOIL_CULTS)
+		BLOODBOIL_CULTS = setBLOODBOIL_CULTS
+	if(setBURNINGBLOOD_CULTS)
+		BURNINGBLOOD_CULTS = setBURNINGBLOOD_CULTS
+	update_tome()
 
 /obj/effect/rune
 /////////////////////////////////////////FIRST RUNE
@@ -62,7 +90,7 @@ var/list/sacrificed = list()
 			culcount++
 	if(user.loc==src.loc)
 		return fizzle(user)
-	if(culcount>=1)
+	if(culcount>=ITEMPORT_CULTS)
 		user.say("Sas[pick("'","`")]so c'arta forbici tarem!")
 		user.visible_message("<span class='danger'>You feel air moving from the rune - like as it was swapped with somewhere else.</span>", \
 		"<span class='danger'>You feel air moving from the rune - like as it was swapped with somewhere else.</span>", \
@@ -108,7 +136,7 @@ var/list/sacrificed = list()
 			if(iscultist(C) && !C.stat)		//converting requires three cultists
 				cultsinrange += C
 				C.say("Mah[pick("'","`")]weyh pleggh at e'ntrath!")
-		if(cultsinrange.len >= 3)
+		if(cultsinrange.len >= CONVERT_CULTS)
 			M.visible_message("<span class='danger'>[M] writhes in pain as the markings below him glow a bloody red.</span>", \
 			"<span class='danger'>AAAAAAHHHH!</span>", \
 			"<span class='danger'>You hear an anguished scream.</span>")
@@ -157,7 +185,7 @@ var/list/sacrificed = list()
 	for(var/mob/M in range(1,src))
 		if(iscultist(M) && !M.stat)
 			cultist_count += M
-	if(cultist_count.len >= 9)
+	if(cultist_count.len >= ELDERGOD_CULTS)
 		if(ticker.mode.name == "cult")
 			var/datum/game_mode/cult/cultmode = ticker.mode
 			if(!("eldergod" in cultmode.cult_objectives))
@@ -610,11 +638,11 @@ var/list/sacrificed = list()
 		if(iscultist(C) && !C.stat)
 			cultsinrange += C
 			C.say("Barhah hra zar[pick("'","`")]garis!")
-			if(cultsinrange.len >= 3) break		//we only need to check for three alive cultists, loop breaks so their aren't extra cultists getting word rewards
+			if(cultsinrange.len >= SACRIFICE_CULTS) break		//we only need to check for three alive cultists, loop breaks so their aren't extra cultists getting word rewards
 	for(var/mob/H in victims)
 		if (ticker.mode.name == "cult")
 			if(H.mind == ticker.mode:sacrifice_target)
-				if(cultsinrange.len >= 3)
+				if(cultsinrange.len >= SACRIFICE_CULTS)
 					sacrificed += H.mind
 					stone_or_gib(H)
 					for(var/mob/living/carbon/C in cultsinrange)
@@ -626,7 +654,7 @@ var/list/sacrificed = list()
 				else
 					usr << "<span class='danger'>Your target's earthly bonds are too strong. You need more cultists to succeed in this ritual.</span>"
 			else
-				if(cultsinrange.len >= 3)
+				if(cultsinrange.len >= SACRIFICE_CULTS)
 					if(H.stat !=2)
 						for(var/mob/living/carbon/C in cultsinrange)
 							C << "<span class='danger'>The Geometer of Blood accepts this sacrifice.</span>"
@@ -652,7 +680,7 @@ var/list/sacrificed = list()
 							usr << "<span class='danger'>However, a mere dead body is not enough to satisfy Him.</span>"
 						stone_or_gib(H)
 		else
-			if(cultsinrange.len >= 3)
+			if(cultsinrange.len >= SACRIFICE_CULTS)
 				if(H.stat !=2)
 					for(var/mob/living/carbon/C in cultsinrange)
 						C << "<span class='danger'>The Geometer of Blood accepts this sacrifice.</span>"
@@ -680,7 +708,7 @@ var/list/sacrificed = list()
 	for(var/mob/living/carbon/monkey/M in src.loc)
 		if (ticker.mode.name == "cult")
 			if(M.mind == ticker.mode:sacrifice_target)
-				if(cultsinrange.len >= 3)
+				if(cultsinrange.len >= SACRIFICE_CULTS)
 					sacrificed += M.mind
 					for(var/mob/living/carbon/C in cultsinrange)
 						C << "<span class='danger'>The Geometer of Blood accepts this sacrifice, your objective is now complete.</span>"
@@ -808,7 +836,7 @@ var/list/sacrificed = list()
 	for(var/mob/living/C in orange(1,src))
 		if(iscultist(C) && !C.stat)
 			users+=C
-	if(users.len>=1)
+	if(users.len>=FREEDOM_CULTS)
 		var/mob/living/carbon/cultist = input("Choose the one who you want to free", "Followers of Geometer") as null|anything in (cultists - users)
 		if(!cultist)
 			return fizzle(user)
@@ -858,7 +886,7 @@ var/list/sacrificed = list()
 	for(var/mob/living/C in orange(1,src))
 		if(iscultist(C) && !C.stat)
 			users+=C
-	if(users.len>=3)
+	if(users.len>=CULTSUMMON_CULTS)
 		var/mob/living/carbon/cultist = input("Choose the one who you want to summon", "Followers of Geometer") as null|anything in (cultists - user)
 		if(!cultist)
 			return fizzle(user)
@@ -976,7 +1004,7 @@ var/list/sacrificed = list()
 	for(var/mob/living/carbon/C in orange(1,src))
 		if(iscultist(C) && !C.stat)
 			culcount++
-	if(culcount>=3)
+	if(culcount>=BLOODBOIL_CULTS)
 		for(var/mob/living/carbon/M in viewers(usr))
 			if(iscultist(M))
 				continue
@@ -1007,7 +1035,7 @@ var/list/sacrificed = list()
 	for(var/mob/living/carbon/C in orange(1,src))
 		if(iscultist(C) && !C.stat)
 			culcount++
-	if(culcount >= 5)
+	if(culcount >= BURNINGBLOOD_CULTS)
 		for(var/obj/effect/rune/R in world)
 			if(R.blood_DNA == src.blood_DNA)
 				for(var/mob/living/M in orange(2,R))

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -15,13 +15,13 @@
 	config_tag = "revolution"
 	antag_flag = BE_REV
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
-	required_players = 20
+	required_players = 10
 	required_enemies = 1
-	recommended_enemies = 3
+	recommended_enemies = 2
 
 	var/finished = 0
 	var/check_counter = 0
-	var/max_headrevs = 3
+	var/max_headrevs = 2
 	var/list/datum/mind/heads_to_kill = list()
 
 ///////////////////////////
@@ -37,17 +37,23 @@
 ///////////////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/pre_setup()
 
-	if(config.protect_roles_from_antagonist)
-		restricted_jobs += protected_jobs
-
-	if(config.protect_assistant_from_antagonist)
-		restricted_jobs += "Assistant"
+	//adjust the number of headrevs based on player count
+	if(num_players() >= 20) 
+		recommended_enemies = 3
+		max_headrevs = 3
 
 	var/head_check = 0
 	for(var/mob/new_player/player in player_list)
 		if(player.mind.assigned_role in command_positions)
 			head_check = 1
 			break
+
+
+	if(config.protect_roles_from_antagonist)
+		restricted_jobs += protected_jobs
+
+	if(config.protect_assistant_from_antagonist)
+		restricted_jobs += "Assistant"
 
 	for(var/datum/mind/player in antag_candidates)
 		for(var/job in restricted_jobs)//Removing heads and such from the list

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -5,7 +5,7 @@
 	name = "wizard"
 	config_tag = "wizard"
 	antag_flag = BE_WIZARD
-	required_players = 20
+	required_players = 10
 	required_enemies = 1
 	recommended_enemies = 1
 	pre_setup_before_jobs = 1
@@ -155,10 +155,20 @@
 	if(wizard_mob.backbag == 3) wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(wizard_mob), slot_back)
 	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(wizard_mob), slot_in_backpack)
 //	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/scrying_gem(wizard_mob), slot_l_store) For scrying gem.
-	wizard_mob.equip_to_slot_or_del(new /obj/item/weapon/teleportation_scroll(wizard_mob), slot_r_store)
+	//Teleportation Scroll Setup
+	var/obj/item/weapon/teleportation_scroll/telescroll = new /obj/item/weapon/teleportation_scroll(wizard_mob)
+	wizard_mob.equip_to_slot_or_del(telescroll, slot_r_store)
+	
+	//spell book setup
 	var/obj/item/weapon/spellbook/spellbook = new /obj/item/weapon/spellbook(wizard_mob)
 	spellbook.owner = wizard_mob
 	wizard_mob.equip_to_slot_or_del(spellbook, slot_r_hand)
+
+	//Adjust Equipment for lower player counts
+	if(num_players() < 20)
+		spellbook.uses = 3
+		spellbook.max_uses = 3
+		telescroll.uses = 2
 
 	wizard_mob << "You will find a list of available spells in your spell book. Choose your magic arsenal carefully."
 	wizard_mob << "The spellbook is bound to you, and others cannot use it."


### PR DESCRIPTION
Revolution, Wizard, and Cult modes now can start with only 10 players.
They adjust the difficulty by checking the player count and changing
values in the mode's pre_setup() proc or the equip_wizard() proc in the
case of wizard mode. Required number of players/enemies and other
settings were lowered to the lowest setting as default to ensure only
the lowest number of required players and enemies determines if the
round will start.

Revolution Mode:
- If there are less than 20 players, reduced recommended enemies and max
rev heads to 2 from 3
- If there are greater or equal to 20 players the recommended enemies
and max rev heads are set back to the original 3

Wizard Mode:
- in equip_wizard proc I lowered the number of uses/max uses of the
spell book to 3 and uses of the teleport scroll to 2 if there are less
than 20 players.

Cult Mode:
- for less than 20 players: required enemies = 2, recommended enemies =
4, acolytes needed for survive objective = 7, and cultists needed to
summon eldergod = 6
+ additionally: cultists required to use various runes have been
lowered: convert=2, sacrifice=2
- for 20 to less than 30 players: required enemies=4, recommended
enemies=6, acolytes needed=10, cultists required to summon the eldergod
= 9
+ additionally cultists required to use runes are their original values:
convert=3, sacrifice=3
- for 30 or more players: required enemies = 6, recommended enemies = 9,
acolytes needed=15, and runes are the same as for >= 20 players

Additionally:
- For all cult runes that check how many cultists are around the
required number of cultists has been stored as a variable so that it can
be changed
- the tome now lists the number of cultists required to use each rune,
this number is updated when the update_tome() proc is called
- the set_runecults() proc is added as a convenient way to change the
number of cultists required to activate the various runes. Each rune is
a named argument with a default value of null so you can change only the
runes specified. It also calls update_tome() at the end to keep the tome
up to date on rune requirements and as such is the preferred way to
change cultist requirements for runes.